### PR TITLE
[Feature] 사용자 도메인 구현 완료

### DIFF
--- a/src/main/java/kr/teammanagers/alarm/domain/Alarm.java
+++ b/src/main/java/kr/teammanagers/alarm/domain/Alarm.java
@@ -2,7 +2,7 @@ package kr.teammanagers.alarm.domain;
 
 import jakarta.persistence.*;
 import kr.teammanagers.common.AuditingField;
-import kr.teammanagers.schedule.domain.TeamSchedule;
+import kr.teammanagers.schedule.domain.TeamCalendar;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -30,7 +30,7 @@ public class Alarm extends AuditingField {
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_schedule_id")
-    private TeamSchedule teamSchedule;
+    private TeamCalendar teamSchedule;
 
     @Builder
     private Alarm(final String title, final String content, final LocalDate date) {

--- a/src/main/java/kr/teammanagers/common/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/kr/teammanagers/common/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package kr.teammanagers.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    protected MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/kr/teammanagers/common/payload/code/ApiPayload.java
+++ b/src/main/java/kr/teammanagers/common/payload/code/ApiPayload.java
@@ -21,8 +21,18 @@ public record ApiPayload<T>(
         return new ApiPayload<>(
                 true,
                 SuccessStatus._OK.getCode(),
-                SuccessStatus._ACCEPTED.getMessage(),
+                SuccessStatus._OK.getMessage(),
                 result
+        );
+    }
+
+    // Success : No result
+    public static <T> ApiPayload<T> onSuccess() {
+        return new ApiPayload<>(
+                true,
+                SuccessStatus._OK.getCode(),
+                SuccessStatus._OK.getMessage(),
+                null
         );
     }
 
@@ -30,7 +40,7 @@ public record ApiPayload<T>(
         return new ApiPayload<>(
                 true,
                 SuccessStatus._OK.getCode(),
-                SuccessStatus._ACCEPTED.getMessage(),
+                SuccessStatus._OK.getMessage(),
                 result
         );
     }

--- a/src/main/java/kr/teammanagers/global/constant/AmazonConstant.java
+++ b/src/main/java/kr/teammanagers/global/constant/AmazonConstant.java
@@ -3,6 +3,5 @@ package kr.teammanagers.global.constant;
 public final class AmazonConstant {
 
     private AmazonConstant() {}
-
-    public static final String FILE_UPLODAD_ERROR = "파일을 업로드하는데 오류가 발생했습니다.";
+    public static final String FILE_UPLOAD_ERROR = "파일을 업로드하는데 오류가 발생했습니다.";
 }

--- a/src/main/java/kr/teammanagers/global/provider/AmazonS3Provider.java
+++ b/src/main/java/kr/teammanagers/global/provider/AmazonS3Provider.java
@@ -31,7 +31,7 @@ public class AmazonS3Provider {
         try {
             amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
         } catch (IOException e) {
-            log.error(AmazonConstant.FILE_UPLODAD_ERROR + ": {}", (Object) e.getStackTrace());
+            log.error(AmazonConstant.FILE_UPLOAD_ERROR + ": {}", (Object) e.getStackTrace());
         }
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
@@ -48,7 +48,7 @@ public class AmazonS3Provider {
             amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName + ext, file.getInputStream(), metadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
-            log.error(AmazonConstant.FILE_UPLODAD_ERROR + ": {}", (Object) e.getStackTrace());
+            log.error(AmazonConstant.FILE_UPLOAD_ERROR + ": {}", (Object) e.getStackTrace());
         }
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName + ext).toString();
     }

--- a/src/main/java/kr/teammanagers/member/application/MemberService.java
+++ b/src/main/java/kr/teammanagers/member/application/MemberService.java
@@ -1,15 +1,134 @@
 package kr.teammanagers.member.application;
 
+import kr.teammanagers.global.config.AmazonConfig;
+import kr.teammanagers.global.provider.AmazonS3Provider;
+import kr.teammanagers.member.domain.Comment;
+import kr.teammanagers.member.domain.Member;
+import kr.teammanagers.member.dto.request.UpdateProfile;
+import kr.teammanagers.member.dto.response.GetMemberTeam;
+import kr.teammanagers.member.dto.response.GetPortfolio;
+import kr.teammanagers.member.dto.response.GetProfile;
+import kr.teammanagers.member.dto.response.GetSimplePortfolioList;
+import kr.teammanagers.member.repository.CommentRepository;
 import kr.teammanagers.member.repository.MemberRepository;
+import kr.teammanagers.storage.domain.TeamData;
+import kr.teammanagers.storage.repository.TeamDataRepository;
+import kr.teammanagers.tag.application.TagModuleService;
+import kr.teammanagers.tag.domain.ConfidentRole;
+import kr.teammanagers.tag.domain.Tag;
+import kr.teammanagers.tag.repository.ConfidentRoleRepository;
+import kr.teammanagers.team.domain.Team;
+import kr.teammanagers.team.domain.TeamManage;
+import kr.teammanagers.team.repository.TeamManageRepository;
+import kr.teammanagers.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
+    private final TeamDataRepository teamDataRepository;
+    private final TeamManageRepository teamManageRepository;
+    private final TagModuleService tagModuleService;
+    private final ConfidentRoleRepository confidentRoleRepository;
+    private final TeamRepository teamRepository;
+    private final AmazonConfig amazonConfig;
+    private final AmazonS3Provider amazonS3Provider;
 
+    public GetProfile getProfile(final Long authId) {
+        Member member = memberRepository.findById(authId).orElseThrow(RuntimeException::new);       // TODO : 예외 처리 필요
+        List<Tag> tagList = tagModuleService.getAllConfidentRole(authId);
+        List<Comment> commentList = commentRepository.findAllByMemberId(authId);
+        return GetProfile.from(member, tagList, commentList);
+    }
+
+    @Transactional
+    public void updateProfile(final Long authId, final UpdateProfile request, final MultipartFile imageFile) {
+       log.info("imageFile: {}", imageFile);
+        Member member = memberRepository.findById(authId).orElseThrow(RuntimeException::new);       // TODO : 예외 처리 필요
+        if (request.belong() != null) {
+            member.updateBelong(request.belong());
+        }
+        if (request.confidentRole() != null) {
+            List<ConfidentRole> currentConfidentRoleList = confidentRoleRepository.findAllByMemberId(member.getId());
+
+            request.confidentRole().stream()
+                    .filter(tagName -> !currentConfidentRoleList.stream()
+                            .map(confidentRole -> confidentRole.getTag().getName())
+                            .toList().contains(tagName)
+                    )
+                    .forEach(tagName -> tagModuleService.createConfidentRole(tagName, member));
+
+            currentConfidentRoleList.stream()
+                    .filter(tag -> !request.confidentRole().contains(tag.getTag().getName()))
+                    .forEach(tagModuleService::deleteConfidentRole);
+        }
+        if (imageFile != null) {
+            updateProfileImage(imageFile, member);
+        }
+    }
+
+
+    @Transactional
+    public void updateCommentState(final Long authId, final Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(RuntimeException::new);     // TODO : 예외 처리 필요
+        comment.updateIsHidden();
+    }
+
+    public GetSimplePortfolioList getSimplePortfolioList(final Long authId) {
+        List<Team> teamList = teamManageRepository.findAllByMemberId(authId).stream()
+                .map(TeamManage::getTeam)
+                .toList();
+        return GetSimplePortfolioList.from(teamList);
+    }
+
+    public GetPortfolio getPortfolio(final Long authId, final Long teamId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(RuntimeException::new);     // TODO : 예외 처리 필요
+        List<TeamManage> teamManageList = teamManageRepository.findAllByTeamId(teamId);
+
+        List<Member> memberList = teamManageRepository.findAllByTeamId(teamId).stream()
+                .map(TeamManage::getMember)
+                .toList();
+
+        List<Tag> teamRoleList = tagModuleService.getAllTeamRoleTag(
+                teamManageList.stream()
+                        .filter(teamManage -> teamManage.getId().equals(authId))
+                        .findFirst()
+                        .orElseThrow(RuntimeException::new)
+                        .getId());
+
+        List<TeamData> teamDataList = teamManageList.stream()
+                .flatMap(teamManage -> teamDataRepository.findAllByTeamManageId(teamManage.getId()).stream())
+                .toList();
+
+        return GetPortfolio.from(team, tagModuleService.getAllTeamTag(teamId), memberList, teamRoleList, teamDataList);
+    }
+
+
+    public GetMemberTeam getMemberTeam(final Long authId) {
+        Member member = memberRepository.findById(authId).orElseThrow(RuntimeException::new);       // TODO : 예외 처리 필요
+        List<Team> teamList = teamManageRepository.findAllByMemberId(authId).stream()
+                .map(TeamManage::getTeam)
+                .toList();
+        return GetMemberTeam.from(member, teamList);
+    }
+
+    private void updateProfileImage(final MultipartFile imageFile, final Member member) {
+        if (member.getImageUrl() != null) {
+            amazonS3Provider.deleteFile(
+                    amazonS3Provider.extractImageNameFromUrl(member.getImageUrl()));
+        }
+        member.updateImageUrl(amazonS3Provider.uploadImage(
+                amazonS3Provider.generateKeyName(amazonConfig.getMemberProfilePath()), imageFile));
+    }
 }

--- a/src/main/java/kr/teammanagers/member/application/MemberService.java
+++ b/src/main/java/kr/teammanagers/member/application/MemberService.java
@@ -1,0 +1,15 @@
+package kr.teammanagers.member.application;
+
+import kr.teammanagers.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+}

--- a/src/main/java/kr/teammanagers/member/domain/Comment.java
+++ b/src/main/java/kr/teammanagers/member/domain/Comment.java
@@ -1,0 +1,38 @@
+package kr.teammanagers.member.domain;
+
+import jakarta.persistence.*;
+import kr.teammanagers.common.AuditingField;
+import lombok.*;
+
+@Entity
+@Table(name = "comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Comment extends AuditingField {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String content;
+
+    @Column(nullable = false)
+    private Boolean isHidden;
+
+    // Mapping
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    private Comment(final String content, final Boolean isHidden) {
+        this.content = content;
+        this.isHidden = isHidden;
+    }
+
+    public void updateIsHidden() {
+        this.isHidden = !this.isHidden;
+    }
+}

--- a/src/main/java/kr/teammanagers/member/domain/Member.java
+++ b/src/main/java/kr/teammanagers/member/domain/Member.java
@@ -46,4 +46,12 @@ public class Member extends AuditingField {
         this.phoneNumber = phoneNumber;
         this.belong = belong;
     }
+
+    public void updateBelong(final String belong) {
+        this.belong = belong;
+    }
+
+    public void updateImageUrl(final String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/kr/teammanagers/member/dto/SimplePortfolioDto.java
+++ b/src/main/java/kr/teammanagers/member/dto/SimplePortfolioDto.java
@@ -1,5 +1,6 @@
 package kr.teammanagers.member.dto;
 
+import kr.teammanagers.team.domain.Team;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -11,4 +12,13 @@ public record SimplePortfolioDto(
         LocalDateTime start,
         LocalDateTime end
 ) {
+
+    public static SimplePortfolioDto from(final Team team) {
+        return SimplePortfolioDto.builder()
+                .teamId(team.getId())
+                .name(team.getTitle())
+                .start(team.getCreatedAt())
+                .end(team.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/member/dto/SimplePortfolioDto.java
+++ b/src/main/java/kr/teammanagers/member/dto/SimplePortfolioDto.java
@@ -1,0 +1,14 @@
+package kr.teammanagers.member.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record SimplePortfolioDto(
+        Long teamId,
+        String name,
+        LocalDateTime start,
+        LocalDateTime end
+) {
+}

--- a/src/main/java/kr/teammanagers/member/dto/request/UpdateProfile.java
+++ b/src/main/java/kr/teammanagers/member/dto/request/UpdateProfile.java
@@ -1,15 +1,12 @@
 package kr.teammanagers.member.dto.request;
 
 import jakarta.validation.constraints.Size;
-import kr.teammanagers.tag.dto.TagDto;
-import kr.teammanagers.team.dto.CommentDto;
 
 import java.util.List;
 
 public record UpdateProfile(
         @Size(max = 20)
         String belong,
-        List<TagDto> confidentRole,
-        List<CommentDto> commentList
+        List<String> confidentRole
 ) {
 }

--- a/src/main/java/kr/teammanagers/member/dto/request/UpdateProfile.java
+++ b/src/main/java/kr/teammanagers/member/dto/request/UpdateProfile.java
@@ -1,0 +1,15 @@
+package kr.teammanagers.member.dto.request;
+
+import jakarta.validation.constraints.Size;
+import kr.teammanagers.tag.dto.TagDto;
+import kr.teammanagers.team.dto.CommentDto;
+
+import java.util.List;
+
+public record UpdateProfile(
+        @Size(max = 20)
+        String belong,
+        List<TagDto> confidentRole,
+        List<CommentDto> commentList
+) {
+}

--- a/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
@@ -1,11 +1,24 @@
 package kr.teammanagers.member.dto.response;
 
+import kr.teammanagers.member.domain.Member;
+import kr.teammanagers.team.domain.Team;
 import kr.teammanagers.team.dto.TeamDto;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record GetMemberTeam(
         String name,
         List<TeamDto> teamList
 ) {
+
+    public static GetMemberTeam from(final Member member, final List<Team> teamList) {
+        return GetMemberTeam.builder()
+                .name(member.getName())
+                .teamList(teamList.stream()
+                        .map(TeamDto::from)
+                        .toList())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.member.dto.response;
+
+import kr.teammanagers.team.dto.TeamDto;
+
+import java.util.List;
+
+public record GetMemberTeam(
+        String name,
+        List<TeamDto> teamList
+) {
+}

--- a/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
@@ -13,7 +13,7 @@ public record GetMemberTeam(
         List<TeamDto> teamList
 ) {
 
-    public static GetMemberTeam from(final Member member, final List<Team> teamList) {
+    public static GetMemberTeam of(final Member member, final List<Team> teamList) {
         return GetMemberTeam.builder()
                 .name(member.getName())
                 .teamList(teamList.stream()

--- a/src/main/java/kr/teammanagers/member/dto/response/GetPortfolio.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetPortfolio.java
@@ -1,0 +1,18 @@
+package kr.teammanagers.member.dto.response;
+
+import kr.teammanagers.storage.dto.StorageDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetPortfolio(
+        Long teamId,
+        String name,
+        LocalDateTime start,
+        LocalDateTime end,
+        List<String> teamTagList,
+        List<String> teamMemberList,
+        List<String> teamMyRole,
+        List<StorageDto> storageList
+) {
+}

--- a/src/main/java/kr/teammanagers/member/dto/response/GetPortfolio.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetPortfolio.java
@@ -1,10 +1,16 @@
 package kr.teammanagers.member.dto.response;
 
+import kr.teammanagers.member.domain.Member;
+import kr.teammanagers.storage.domain.TeamData;
 import kr.teammanagers.storage.dto.StorageDto;
+import kr.teammanagers.tag.domain.Tag;
+import kr.teammanagers.team.domain.Team;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
 public record GetPortfolio(
         Long teamId,
         String name,
@@ -15,4 +21,25 @@ public record GetPortfolio(
         List<String> teamMyRole,
         List<StorageDto> storageList
 ) {
+
+    public static GetPortfolio from(final Team team, final List<Tag> teamTagList, final List<Member> memberList, final List<Tag> teamRoleList, final List<TeamData> storageList) {
+        return GetPortfolio.builder()
+                .teamId(team.getId())
+                .name(team.getTitle())
+                .start(team.getCreatedAt())
+                .end(team.getUpdatedAt())
+                .teamTagList(teamTagList.stream()
+                        .map(Tag::getName)
+                        .toList())
+                .teamMemberList(memberList.stream()
+                        .map(Member::getName)
+                        .toList())
+                .teamMyRole(teamRoleList.stream()
+                        .map(Tag::getName)
+                        .toList())
+                .storageList(storageList.stream()
+                        .map(StorageDto::from)
+                        .toList())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/member/dto/response/GetPortfolio.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetPortfolio.java
@@ -22,7 +22,7 @@ public record GetPortfolio(
         List<StorageDto> storageList
 ) {
 
-    public static GetPortfolio from(final Team team, final List<Tag> teamTagList, final List<Member> memberList, final List<Tag> teamRoleList, final List<TeamData> storageList) {
+    public static GetPortfolio of(final Team team, final List<Tag> teamTagList, final List<Member> memberList, final List<Tag> teamRoleList, final List<TeamData> storageList) {
         return GetPortfolio.builder()
                 .teamId(team.getId())
                 .name(team.getTitle())

--- a/src/main/java/kr/teammanagers/member/dto/response/GetProfile.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetProfile.java
@@ -1,5 +1,8 @@
 package kr.teammanagers.member.dto.response;
 
+import kr.teammanagers.member.domain.Comment;
+import kr.teammanagers.member.domain.Member;
+import kr.teammanagers.tag.domain.Tag;
 import kr.teammanagers.tag.dto.TagDto;
 import kr.teammanagers.team.dto.CommentDto;
 import lombok.Builder;
@@ -14,4 +17,22 @@ public record GetProfile(
         List<TagDto> confidentRole,
         List<CommentDto> commentList
 ) {
+
+    public static GetProfile from(final Member member, final List<Tag> tagList, final List<Comment> commentList) {
+        return GetProfile.builder()
+                .imageUrl(member.getImageUrl())
+                .name(member.getName())
+                .belong(member.getBelong())
+                .confidentRole(
+                        tagList.stream()
+                                .map(TagDto::of)
+                                .toList()
+                )
+                .commentList(
+                        commentList.stream()
+                                .map(CommentDto::of)
+                                .toList()
+                )
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/member/dto/response/GetProfile.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetProfile.java
@@ -1,0 +1,17 @@
+package kr.teammanagers.member.dto.response;
+
+import kr.teammanagers.tag.dto.TagDto;
+import kr.teammanagers.team.dto.CommentDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetProfile(
+        String imageUrl,
+        String name,
+        String belong,
+        List<TagDto> confidentRole,
+        List<CommentDto> commentList
+) {
+}

--- a/src/main/java/kr/teammanagers/member/dto/response/GetProfile.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetProfile.java
@@ -25,12 +25,12 @@ public record GetProfile(
                 .belong(member.getBelong())
                 .confidentRole(
                         tagList.stream()
-                                .map(TagDto::of)
+                                .map(TagDto::from)
                                 .toList()
                 )
                 .commentList(
                         commentList.stream()
-                                .map(CommentDto::of)
+                                .map(CommentDto::from)
                                 .toList()
                 )
                 .build();

--- a/src/main/java/kr/teammanagers/member/dto/response/GetSimplePortfolioList.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetSimplePortfolioList.java
@@ -1,0 +1,10 @@
+package kr.teammanagers.member.dto.response;
+
+import kr.teammanagers.member.dto.SimplePortfolioDto;
+
+import java.util.List;
+
+public record GetSimplePortfolioList(
+        List<SimplePortfolioDto> portfolioList
+) {
+}

--- a/src/main/java/kr/teammanagers/member/dto/response/GetSimplePortfolioList.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetSimplePortfolioList.java
@@ -1,10 +1,21 @@
 package kr.teammanagers.member.dto.response;
 
 import kr.teammanagers.member.dto.SimplePortfolioDto;
+import kr.teammanagers.team.domain.Team;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record GetSimplePortfolioList(
         List<SimplePortfolioDto> portfolioList
 ) {
+
+    public static GetSimplePortfolioList from(final List<Team> teamList) {
+        return GetSimplePortfolioList.builder()
+                .portfolioList(teamList.stream()
+                        .map(SimplePortfolioDto::from)
+                        .toList())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/member/presentation/MemberController.java
+++ b/src/main/java/kr/teammanagers/member/presentation/MemberController.java
@@ -1,9 +1,16 @@
 package kr.teammanagers.member.presentation;
 
+import kr.teammanagers.common.payload.code.ApiPayload;
 import kr.teammanagers.member.application.MemberService;
+import kr.teammanagers.member.dto.request.UpdateProfile;
+import kr.teammanagers.member.dto.response.GetMemberTeam;
+import kr.teammanagers.member.dto.response.GetPortfolio;
+import kr.teammanagers.member.dto.response.GetProfile;
+import kr.teammanagers.member.dto.response.GetSimplePortfolioList;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api")
@@ -12,4 +19,55 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @GetMapping("/member")
+    public ApiPayload<GetProfile> getProfile(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+    ) {
+        GetProfile result = memberService.getProfile(1L);           // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess(result);
+    }
+
+    @PatchMapping(value = "/member", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiPayload<?> updateProfile(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @RequestPart(name = "updateProfile") final UpdateProfile updateProfile,
+            @RequestPart(name = "imageFile", required = false) final MultipartFile imageFile
+    ) {
+        memberService.updateProfile(1L, updateProfile, imageFile);             // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess();
+    }
+
+    @PatchMapping( "/comment/{commentId}/state")
+    public ApiPayload<?> updateCommentState(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @PathVariable(name = "commentId") final Long commentId
+    ) {
+        memberService.updateCommentState(1L, commentId);            // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess();
+    }
+
+    @GetMapping("/member/portfolio")
+    public ApiPayload<GetSimplePortfolioList> getSimplePortfolioList(
+//            @AuthenticationPrincipal AuthDto auth,                                // TODO : 인증 객체 구현 필요
+    ) {
+        GetSimplePortfolioList result = memberService.getSimplePortfolioList(1L);   // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess(result);
+    }
+
+    @GetMapping("/member/portfolio/{teamId}")
+    public ApiPayload<GetPortfolio> getPortfolio(
+//            @AuthenticationPrincipal AuthDto auth,                                // TODO : 인증 객체 구현 필요
+            @PathVariable(name = "teamId") final Long teamId
+    ) {
+        GetPortfolio result = memberService.getPortfolio(1L, teamId);               // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess(result);
+    }
+
+    @GetMapping("/member/team")
+    public ApiPayload<GetMemberTeam> getMemberTeam(
+//            @AuthenticationPrincipal AuthDto auth,                                // TODO : 인증 객체 구현 필요
+    ) {
+        GetMemberTeam result = memberService.getMemberTeam(1L);                     // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess(result);
+    }
 }

--- a/src/main/java/kr/teammanagers/member/presentation/MemberController.java
+++ b/src/main/java/kr/teammanagers/member/presentation/MemberController.java
@@ -1,0 +1,15 @@
+package kr.teammanagers.member.presentation;
+
+import kr.teammanagers.member.application.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+}

--- a/src/main/java/kr/teammanagers/member/repository/CommentRepository.java
+++ b/src/main/java/kr/teammanagers/member/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.member.repository;
+
+import kr.teammanagers.member.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/kr/teammanagers/member/repository/MemberQueryDslImpl.java
+++ b/src/main/java/kr/teammanagers/member/repository/MemberQueryDslImpl.java
@@ -1,4 +1,11 @@
 package kr.teammanagers.member.repository;
 
-public class MemberQueryDslImpl implements MemberQueryDsl{
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberQueryDslImpl implements MemberQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
 }

--- a/src/main/java/kr/teammanagers/schedule/domain/Calendar.java
+++ b/src/main/java/kr/teammanagers/schedule/domain/Calendar.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "schedule")
+@Table(name = "calendar")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Schedule extends AuditingField {
+public class Calendar extends AuditingField {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +32,7 @@ public class Schedule extends AuditingField {
     private Status status;
 
     @Builder
-    private Schedule(final String title, final String content, final LocalDateTime date, final Status status) {
+    private Calendar(final String title, final String content, final LocalDateTime date, final Status status) {
         this.title = title;
         this.content = content;
         this.date = date;

--- a/src/main/java/kr/teammanagers/schedule/domain/TeamCalendar.java
+++ b/src/main/java/kr/teammanagers/schedule/domain/TeamCalendar.java
@@ -6,10 +6,10 @@ import kr.teammanagers.team.domain.TeamManage;
 import lombok.*;
 
 @Entity
-@Table(name = "team_schedule")
+@Table(name = "team_calendar")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TeamSchedule extends AuditingField {
+public class TeamCalendar extends AuditingField {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,8 +21,8 @@ public class TeamSchedule extends AuditingField {
     // Mapping
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "schedule_id")
-    private Schedule schedule;
+    @JoinColumn(name = "calendar_id")
+    private Calendar schedule;
 
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
@@ -30,7 +30,7 @@ public class TeamSchedule extends AuditingField {
     private TeamManage teamManage;
 
     @Builder
-    private TeamSchedule(final Boolean isAlarmed) {
+    private TeamCalendar(final Boolean isAlarmed) {
         this.isAlarmed = isAlarmed;
     }
 }

--- a/src/main/java/kr/teammanagers/storage/dto/StorageDto.java
+++ b/src/main/java/kr/teammanagers/storage/dto/StorageDto.java
@@ -1,7 +1,11 @@
 package kr.teammanagers.storage.dto;
 
+import kr.teammanagers.storage.domain.TeamData;
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record StorageDto(
         Long storageId,
         String title,
@@ -10,4 +14,15 @@ public record StorageDto(
         String fileUrl,
         String uploader
 ) {
+
+    public static StorageDto from(final TeamData teamData) {
+        return StorageDto.builder()
+                .storageId(teamData.getId())
+                .title(teamData.getTitle())
+                .size(teamData.getSize())
+                .uploadAt(teamData.getCreatedAt())
+                .fileUrl(teamData.getFileUrl())
+                .uploader(teamData.getTeamManage().getMember().getName())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/storage/dto/StorageDto.java
+++ b/src/main/java/kr/teammanagers/storage/dto/StorageDto.java
@@ -1,0 +1,13 @@
+package kr.teammanagers.storage.dto;
+
+import java.time.LocalDateTime;
+
+public record StorageDto(
+        Long storageId,
+        String title,
+        String size,
+        LocalDateTime uploadAt,
+        String fileUrl,
+        String uploader
+) {
+}

--- a/src/main/java/kr/teammanagers/storage/repository/TeamDataRepository.java
+++ b/src/main/java/kr/teammanagers/storage/repository/TeamDataRepository.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.storage.repository;
+
+import kr.teammanagers.storage.domain.TeamData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TeamDataRepository extends JpaRepository<TeamData, Long> {
+
+    List<TeamData> findAllByTeamManageId(Long teamManageId);
+}

--- a/src/main/java/kr/teammanagers/tag/application/TagModuleService.java
+++ b/src/main/java/kr/teammanagers/tag/application/TagModuleService.java
@@ -1,0 +1,73 @@
+package kr.teammanagers.tag.application;
+
+import kr.teammanagers.member.domain.Member;
+import kr.teammanagers.tag.domain.ConfidentRole;
+import kr.teammanagers.tag.domain.Tag;
+import kr.teammanagers.tag.domain.TagTeam;
+import kr.teammanagers.tag.domain.TeamRole;
+import kr.teammanagers.tag.repository.ConfidentRoleRepository;
+import kr.teammanagers.tag.repository.TagRepository;
+import kr.teammanagers.tag.repository.TagTeamRepository;
+import kr.teammanagers.team.repository.TeamRoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TagModuleService {
+
+    private final TagRepository tagRepository;
+    private final ConfidentRoleRepository confidentRoleRepository;
+    private final TagTeamRepository tagTeamRepository;
+    private final TeamRoleRepository teamRoleRepository;
+
+    public List<Tag> getAllConfidentRole(final Long authId) {
+        return confidentRoleRepository.findAllByMemberId(authId).stream()
+                .map(ConfidentRole::getTag)
+                .toList();
+    }
+
+    public List<Tag> getAllTeamTag(final Long teamId) {
+        return tagTeamRepository.findAllByTeamId(teamId).stream()
+                .map(TagTeam::getTag)
+                .toList();
+    }
+
+    public List<Tag> getAllTeamRoleTag(final Long teamManageId) {
+        return teamRoleRepository.findAllByTeamManageId(teamManageId).stream()
+                .map(TeamRole::getTag)
+                .toList();
+    }
+
+    public void createConfidentRole(final String tagName, final Member member) {
+        tagRepository.findByName(tagName).ifPresentOrElse(tag -> {
+                    confidentRoleRepository.save(ConfidentRole.builder()
+                            .member(member)
+                            .tag(tag)
+                            .build()
+                    );
+                },
+                () -> {
+                    Tag tag = tagRepository.save(Tag.builder()
+                            .name(tagName)
+                            .build());
+                    confidentRoleRepository.save(ConfidentRole.builder()
+                            .member(member)
+                            .tag(tag)
+                            .build()
+                    );
+                });
+    }
+
+    public void deleteConfidentRole(final ConfidentRole confidentRole) {
+        Long tagId = confidentRole.getTag().getId();
+        confidentRoleRepository.delete(confidentRole);
+        if (!confidentRoleRepository.existsByTagId(tagId)) {
+            tagRepository.deleteById(tagId);
+        }
+    }
+}

--- a/src/main/java/kr/teammanagers/tag/domain/ConfidentRole.java
+++ b/src/main/java/kr/teammanagers/tag/domain/ConfidentRole.java
@@ -3,10 +3,7 @@ package kr.teammanagers.tag.domain;
 import jakarta.persistence.*;
 import kr.teammanagers.common.AuditingField;
 import kr.teammanagers.member.domain.Member;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(name = "confident_role")
@@ -28,4 +25,10 @@ public class ConfidentRole extends AuditingField {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    private ConfidentRole(final Tag tag, final Member member) {
+        this.tag = tag;
+        this.member = member;
+    }
 }

--- a/src/main/java/kr/teammanagers/tag/dto/TagDto.java
+++ b/src/main/java/kr/teammanagers/tag/dto/TagDto.java
@@ -1,5 +1,6 @@
 package kr.teammanagers.tag.dto;
 
+import kr.teammanagers.tag.domain.Tag;
 import lombok.Builder;
 
 @Builder
@@ -7,4 +8,11 @@ public record TagDto(
         Long tagId,
         String name
 ) {
+
+    public static TagDto of(final Tag tag) {
+        return TagDto.builder()
+                .tagId(tag.getId())
+                .name(tag.getName())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/tag/dto/TagDto.java
+++ b/src/main/java/kr/teammanagers/tag/dto/TagDto.java
@@ -1,0 +1,10 @@
+package kr.teammanagers.tag.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TagDto(
+        Long tagId,
+        String name
+) {
+}

--- a/src/main/java/kr/teammanagers/tag/dto/TagDto.java
+++ b/src/main/java/kr/teammanagers/tag/dto/TagDto.java
@@ -9,7 +9,7 @@ public record TagDto(
         String name
 ) {
 
-    public static TagDto of(final Tag tag) {
+    public static TagDto from(final Tag tag) {
         return TagDto.builder()
                 .tagId(tag.getId())
                 .name(tag.getName())

--- a/src/main/java/kr/teammanagers/tag/repository/ConfidentRoleRepository.java
+++ b/src/main/java/kr/teammanagers/tag/repository/ConfidentRoleRepository.java
@@ -1,0 +1,13 @@
+package kr.teammanagers.tag.repository;
+
+import kr.teammanagers.tag.domain.ConfidentRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConfidentRoleRepository extends JpaRepository<ConfidentRole, Long> {
+
+    List<ConfidentRole> findAllByMemberId(Long memberId);
+
+    boolean existsByTagId(Long tagId);
+}

--- a/src/main/java/kr/teammanagers/tag/repository/TagRepository.java
+++ b/src/main/java/kr/teammanagers/tag/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.tag.repository;
+
+import kr.teammanagers.tag.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/kr/teammanagers/tag/repository/TagTeamRepository.java
+++ b/src/main/java/kr/teammanagers/tag/repository/TagTeamRepository.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.tag.repository;
+
+import kr.teammanagers.tag.domain.TagTeam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TagTeamRepository extends JpaRepository<TagTeam, Long> {
+
+    List<TagTeam> findAllByTeamId(Long teamId);
+}

--- a/src/main/java/kr/teammanagers/team/dto/CommentDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/CommentDto.java
@@ -1,11 +1,20 @@
 package kr.teammanagers.team.dto;
 
+import kr.teammanagers.member.domain.Comment;
 import lombok.Builder;
 
 @Builder
 public record CommentDto(
-        Long teamManageId,
+        Long commentId,
         String content,
         Boolean isHidden
 ) {
+
+    public static CommentDto of(final Comment comment) {
+        return CommentDto.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .isHidden(comment.getIsHidden())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/team/dto/CommentDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/CommentDto.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.team.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CommentDto(
+        Long teamManageId,
+        String content,
+        Boolean isHidden
+) {
+}

--- a/src/main/java/kr/teammanagers/team/dto/CommentDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/CommentDto.java
@@ -10,7 +10,7 @@ public record CommentDto(
         Boolean isHidden
 ) {
 
-    public static CommentDto of(final Comment comment) {
+    public static CommentDto from(final Comment comment) {
         return CommentDto.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())

--- a/src/main/java/kr/teammanagers/team/dto/TeamDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/TeamDto.java
@@ -1,9 +1,12 @@
 package kr.teammanagers.team.dto;
 
 import kr.teammanagers.tag.dto.TagDto;
+import kr.teammanagers.team.domain.Team;
+import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 public record TeamDto(
         Long teamId,
         String title,
@@ -11,4 +14,13 @@ public record TeamDto(
         String imageUrl,
         List<TagDto> teamTagList
 ) {
+
+    public static TeamDto from(final Team team) {
+        return TeamDto.builder()
+                .teamId(team.getId())
+                .title(team.getTitle())
+                .teamCode(team.getTeamCode())
+                .imageUrl(team.getTeamImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/kr/teammanagers/team/dto/TeamDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/TeamDto.java
@@ -1,0 +1,14 @@
+package kr.teammanagers.team.dto;
+
+import kr.teammanagers.tag.dto.TagDto;
+
+import java.util.List;
+
+public record TeamDto(
+        Long teamId,
+        String title,
+        String teamCode,
+        String imageUrl,
+        List<TagDto> teamTagList
+) {
+}

--- a/src/main/java/kr/teammanagers/team/repository/TeamManageRepository.java
+++ b/src/main/java/kr/teammanagers/team/repository/TeamManageRepository.java
@@ -1,0 +1,13 @@
+package kr.teammanagers.team.repository;
+
+import kr.teammanagers.team.domain.TeamManage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TeamManageRepository extends JpaRepository<TeamManage, Long> {
+
+    List<TeamManage> findAllByMemberId(Long memberId);
+
+    List<TeamManage> findAllByTeamId(Long teamId);
+}

--- a/src/main/java/kr/teammanagers/team/repository/TeamRepository.java
+++ b/src/main/java/kr/teammanagers/team/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package kr.teammanagers.team.repository;
+
+import kr.teammanagers.team.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/kr/teammanagers/team/repository/TeamRoleRepository.java
+++ b/src/main/java/kr/teammanagers/team/repository/TeamRoleRepository.java
@@ -1,0 +1,11 @@
+package kr.teammanagers.team.repository;
+
+import kr.teammanagers.tag.domain.TeamRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TeamRoleRepository extends JpaRepository<TeamRole, Long> {
+
+    List<TeamRole> findAllByTeamManageId(Long teamManageId);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
- #7 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 몇몇 도메인에 관한 정책 수정이 있었습니다. (`Calendar` <-> `Schedule`)
- `Member` 도메인 기능에 관련한 `DTO`를 구현하였습니다.
- `Payload` 메시지 부분에 `OK`가 아닌 `ACCEPTED`가 메시지로 나가는 오류가 있었습니다.
- `Postman` 테스트시 `multipart/form-data`에 대한 정보를 `octet-stream`으로 받는 현상이 있어, 스위칭 클래스를 구현해주었습니다.
- `Tag` 도메인 기능의 비중이 높아, `Repository`와 `Service` 레이어 사이에 `ModuleService`를 구현하였습니다.
- `Comment` 테이블이 추가되어 적용하였습니다.
- `Member` 기능 구현이 완료되었습니다.
- `Member` API 구현이 완료되었습니다.

### 📸 스크린샷 (선택)

### 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- `Tag` 도메인의 패키지 `ModuleService` 구조에 대한 인사이트가 필요합니다.
- `DTO` `Converter`가 팩토리 메서드로 `record` 클래스 내부에서 구현되는 방식이 제대로 이루어지는지 확인 부탁드립니다.