### PR TITLE
[Feature] 팀 도메인 구현 완료

### DIFF
--- a/src/main/java/kr/teammanagers/alarm/domain/Alarm.java
+++ b/src/main/java/kr/teammanagers/alarm/domain/Alarm.java
@@ -2,7 +2,7 @@ package kr.teammanagers.alarm.domain;
 
 import jakarta.persistence.*;
 import kr.teammanagers.common.AuditingField;
-import kr.teammanagers.schedule.domain.TeamCalendar;
+import kr.teammanagers.calendar.domain.TeamCalendar;
 import lombok.*;
 
 import java.time.LocalDate;

--- a/src/main/java/kr/teammanagers/calendar/domain/Calendar.java
+++ b/src/main/java/kr/teammanagers/calendar/domain/Calendar.java
@@ -1,4 +1,4 @@
-package kr.teammanagers.schedule.domain;
+package kr.teammanagers.calendar.domain;
 
 import jakarta.persistence.*;
 import kr.teammanagers.common.AuditingField;

--- a/src/main/java/kr/teammanagers/calendar/domain/TeamCalendar.java
+++ b/src/main/java/kr/teammanagers/calendar/domain/TeamCalendar.java
@@ -1,4 +1,4 @@
-package kr.teammanagers.schedule.domain;
+package kr.teammanagers.calendar.domain;
 
 import jakarta.persistence.*;
 import kr.teammanagers.common.AuditingField;

--- a/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
+++ b/src/main/java/kr/teammanagers/member/dto/response/GetMemberTeam.java
@@ -1,7 +1,6 @@
 package kr.teammanagers.member.dto.response;
 
 import kr.teammanagers.member.domain.Member;
-import kr.teammanagers.team.domain.Team;
 import kr.teammanagers.team.dto.TeamDto;
 import lombok.Builder;
 
@@ -13,12 +12,10 @@ public record GetMemberTeam(
         List<TeamDto> teamList
 ) {
 
-    public static GetMemberTeam of(final Member member, final List<Team> teamList) {
+    public static GetMemberTeam of(final Member member, final List<TeamDto> teamList) {
         return GetMemberTeam.builder()
                 .name(member.getName())
-                .teamList(teamList.stream()
-                        .map(TeamDto::from)
-                        .toList())
+                .teamList(teamList)
                 .build();
     }
 }

--- a/src/main/java/kr/teammanagers/notice/application/NoticeService.java
+++ b/src/main/java/kr/teammanagers/notice/application/NoticeService.java
@@ -4,6 +4,7 @@ import kr.teammanagers.notice.domain.Notice;
 import kr.teammanagers.notice.dto.NoticeDto;
 import kr.teammanagers.notice.dto.request.CreateNotice;
 import kr.teammanagers.notice.dto.response.GetNoticeList;
+import kr.teammanagers.notice.dto.response.GetNoticeRecent;
 import kr.teammanagers.notice.repository.NoticeRepository;
 import kr.teammanagers.team.domain.Team;
 import kr.teammanagers.team.repository.TeamRepository;
@@ -35,5 +36,12 @@ public class NoticeService {
                 .map(NoticeDto::from)
                 .toList();
         return GetNoticeList.from(noticeDtoList);
+    }
+
+    public GetNoticeRecent getNoticeRecent(final Long teamId) {
+        return noticeRepository.findFirstByTeamId(teamId)
+                .map(NoticeDto::from)
+                .map(GetNoticeRecent::from)
+                .orElse(null);
     }
 }

--- a/src/main/java/kr/teammanagers/notice/dto/response/GetNoticeRecent.java
+++ b/src/main/java/kr/teammanagers/notice/dto/response/GetNoticeRecent.java
@@ -1,0 +1,15 @@
+package kr.teammanagers.notice.dto.response;
+
+import kr.teammanagers.notice.dto.NoticeDto;
+import lombok.Builder;
+
+@Builder
+public record GetNoticeRecent(
+        NoticeDto recentNotice
+) {
+    public static GetNoticeRecent from(NoticeDto noticeDto) {
+        return GetNoticeRecent.builder()
+                .recentNotice(noticeDto)
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/notice/presentation/NoticeController.java
+++ b/src/main/java/kr/teammanagers/notice/presentation/NoticeController.java
@@ -4,6 +4,7 @@ import kr.teammanagers.common.payload.code.ApiPayload;
 import kr.teammanagers.notice.application.NoticeService;
 import kr.teammanagers.notice.dto.request.CreateNotice;
 import kr.teammanagers.notice.dto.response.GetNoticeList;
+import kr.teammanagers.notice.dto.response.GetNoticeRecent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,6 +31,15 @@ public class NoticeController {
             @PathVariable("teamId") final Long teamId
     ) {
         GetNoticeList result = noticeService.getNoticeList(teamId);
+        return ApiPayload.onSuccess(result);
+    }
+
+    @GetMapping("/team/{teamId}/notice/recent")
+    public ApiPayload<GetNoticeRecent> getRecent(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @PathVariable("teamId") final Long teamId
+    ) {
+        GetNoticeRecent result = noticeService.getNoticeRecent(teamId);
         return ApiPayload.onSuccess(result);
     }
 }

--- a/src/main/java/kr/teammanagers/notice/repository/NoticeRepository.java
+++ b/src/main/java/kr/teammanagers/notice/repository/NoticeRepository.java
@@ -4,8 +4,11 @@ import kr.teammanagers.notice.domain.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     List<Notice> findAllByTeamId(Long teamId);
+
+    Optional<Notice> findFirstByTeamId(Long teamId);
 }

--- a/src/main/java/kr/teammanagers/schedule/domain/AvailableTime.java
+++ b/src/main/java/kr/teammanagers/schedule/domain/AvailableTime.java
@@ -1,4 +1,4 @@
-package kr.teammanagers.calendar.domain;
+package kr.teammanagers.schedule.domain;
 
 import jakarta.persistence.*;
 import kr.teammanagers.common.AuditingField;

--- a/src/main/java/kr/teammanagers/schedule/domain/TimeTable.java
+++ b/src/main/java/kr/teammanagers/schedule/domain/TimeTable.java
@@ -1,4 +1,4 @@
-package kr.teammanagers.calendar.domain;
+package kr.teammanagers.schedule.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/kr/teammanagers/team/application/TeamService.java
+++ b/src/main/java/kr/teammanagers/team/application/TeamService.java
@@ -1,0 +1,162 @@
+package kr.teammanagers.team.application;
+
+import kr.teammanagers.common.Status;
+import kr.teammanagers.global.config.AmazonConfig;
+import kr.teammanagers.global.provider.AmazonS3Provider;
+import kr.teammanagers.member.domain.Comment;
+import kr.teammanagers.member.domain.Member;
+import kr.teammanagers.member.repository.CommentRepository;
+import kr.teammanagers.member.repository.MemberRepository;
+import kr.teammanagers.tag.application.TagModuleService;
+import kr.teammanagers.tag.domain.Tag;
+import kr.teammanagers.tag.domain.TagTeam;
+import kr.teammanagers.tag.domain.TeamRole;
+import kr.teammanagers.tag.repository.TagTeamRepository;
+import kr.teammanagers.tag.repository.TeamRoleRepository;
+import kr.teammanagers.team.domain.Team;
+import kr.teammanagers.team.domain.TeamManage;
+import kr.teammanagers.team.dto.SimpleTeamMemberDto;
+import kr.teammanagers.team.dto.TeamMemberDto;
+import kr.teammanagers.team.dto.request.CreateTeam;
+import kr.teammanagers.team.dto.request.CreateTeamComment;
+import kr.teammanagers.team.dto.request.CreateTeamPassword;
+import kr.teammanagers.team.dto.response.CreateTeamResult;
+import kr.teammanagers.team.dto.response.GetTeam;
+import kr.teammanagers.team.dto.response.GetTeamMember;
+import kr.teammanagers.team.dto.response.UpdateTeamEndResult;
+import kr.teammanagers.team.repository.TeamManageRepository;
+import kr.teammanagers.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static kr.teammanagers.team.constant.TeamConstant.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+    private final TagTeamRepository tagTeamRepository;
+    private final TeamManageRepository teamManageRepository;
+    private final TeamRoleRepository teamRoleRepository;
+
+    private final TagModuleService tagModuleService;
+    private final AmazonS3Provider amazonS3Provider;
+    private final AmazonConfig amazonConfig;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CreateTeamResult createTeam(final Long authId, final CreateTeam request, final MultipartFile imageFile) {
+        Member member = memberRepository.getReferenceById(authId);
+        String imageUrl = amazonS3Provider.uploadImage(
+                amazonS3Provider.generateKeyName(amazonConfig.getTeamProfilePath()), imageFile);
+        Team team = teamRepository.save(request.toTeam(imageUrl));
+        team.updateTeamCode(encodeNumberToChars(team.getId()));
+
+        request.teamTagList().stream()
+                .map(tagModuleService::findOrCreateTag)
+                .forEach(tag -> tagTeamRepository.save(
+                        TagTeam.builder()
+                                .tag(tag)
+                                .team(team)
+                                .build()
+                ));
+
+        TeamManage admin = TeamManage.builder()
+                .isDeleted(false)
+                .build();
+        admin.setTeam(team);
+        admin.setMember(member);
+        teamManageRepository.save(admin);
+        return CreateTeamResult.from(team);
+    }
+
+    @Transactional
+    public void createTeamPassword(final Long teamId, final CreateTeamPassword request) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(RuntimeException::new);        // TODO : 예외 처리 필요
+        team.updatePassword(request.password());
+    }
+
+    public GetTeam getTeamById(final Long teamId) {
+        return teamRepository.findById(teamId)
+                .map(team -> {
+                    List<Tag> tagList = tagTeamRepository.findAllByTeamId(team.getId()).stream()
+                            .map(TagTeam::getTag).toList();
+                    return GetTeam.from(team, tagList);
+                })
+                .orElseThrow(RuntimeException::new);        // TODO : 예외 처리 필요
+
+    }
+
+    public GetTeam getTeamByTeamCode(final String teamCode) {
+        return teamRepository.findByTeamCode(teamCode)
+                .map(team -> {
+                    List<Tag> tagList = tagTeamRepository.findAllByTeamId(team.getId()).stream()
+                            .map(TagTeam::getTag).toList();
+                    return GetTeam.from(team, tagList);
+                })
+                .orElse(null);
+    }
+
+    public GetTeamMember getTeamMember(final Long teamId) {
+        List<SimpleTeamMemberDto> memberList = teamManageRepository.findAllByTeamId(teamId).stream()
+                .map(SimpleTeamMemberDto::from)
+                .toList();
+
+        return GetTeamMember.from(memberList);
+    }
+
+    @Transactional
+    public UpdateTeamEndResult updateTeamState(final Long authId, final Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(RuntimeException::new);        // TODO : 예외 처리 필요
+        team.updateStatus(Status.COMPLETED);
+        List<TeamMemberDto> teamMemberList = teamManageRepository.findAllByTeamId(teamId).stream()
+                .filter(teamManage -> !teamManage.getMember().getId().equals(authId))
+                .map(teamManage -> {
+                    List<Tag> tagList = teamRoleRepository.findAllByTeamManageId(teamManage.getId()).stream()
+                            .map(TeamRole::getTag).toList();
+                    return TeamMemberDto.of(teamManage, tagList);
+                }).toList();
+
+        return UpdateTeamEndResult.from(teamMemberList);
+    }
+
+    @Transactional
+    public void createComment(final CreateTeamComment request) {
+        request.commentList()
+                .forEach(registerCommentDto -> {
+                    Long memberId = teamManageRepository.findById(registerCommentDto.teamManageId())
+                            .orElseThrow(RuntimeException::new)     // TODO : 예외 처리 필요
+                            .getMember().getId();
+                    Comment comment = Comment.builder()
+                            .content(registerCommentDto.content())
+                            .isHidden(false)
+                            .build();
+                    comment.setMember(memberRepository.getReferenceById(memberId));
+                    commentRepository.save(comment);
+                });
+    }
+
+    private String encodeNumberToChars(final Long teamId) {
+        StringBuilder sb = new StringBuilder();
+        Long number = teamId;
+        while (number > 0) {
+            sb.append(BASE62.charAt((int) (number % BASE)));
+            number /= BASE;
+        }
+
+        while (sb.length() < PADDING) {
+            sb.append(BASE62.charAt(RANDOM.nextInt(BASE)));
+        }
+
+        return sb.reverse().toString();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/constant/TeamConstant.java
+++ b/src/main/java/kr/teammanagers/team/constant/TeamConstant.java
@@ -1,0 +1,14 @@
+package kr.teammanagers.team.constant;
+
+import java.util.Random;
+
+public final class TeamConstant {
+
+    private TeamConstant() {}
+    public static final String DEFAULT_TEAM_PASSWORD = "1234";
+    public static final String BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    public static final int BASE = BASE62.length();
+    public static final Random RANDOM = new Random();
+    public static final int PADDING = 8;
+
+}

--- a/src/main/java/kr/teammanagers/team/domain/Team.java
+++ b/src/main/java/kr/teammanagers/team/domain/Team.java
@@ -24,18 +24,34 @@ public class Team extends AuditingField {
     @Column(name = "team_image_url")
     private String teamImageUrl;
 
-    @Column(name = "team_code", nullable = false, length = 8)
+    @Column(name = "team_code", length = 8)
     private String teamCode;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(nullable = false)
+    private String password;
+
     @Builder
-    private Team(final String title, final String teamImageUrl, final String teamCode, final Status status) {
+    private Team(final String title, final String teamImageUrl, final String teamCode, final Status status, final String password) {
         this.title = title;
         this.teamImageUrl = teamImageUrl;
         this.teamCode = teamCode;
+        this.status = status;
+        this.password = password;
+    }
+
+    public void updateTeamCode(final String teamCode) {
+        this.teamCode = teamCode;
+    }
+
+    public void updatePassword(final String password) {
+        this.password = password;
+    }
+
+    public void updateStatus(final Status status) {
         this.status = status;
     }
 }

--- a/src/main/java/kr/teammanagers/team/dto/RegisterCommentDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/RegisterCommentDto.java
@@ -1,0 +1,7 @@
+package kr.teammanagers.team.dto;
+
+public record RegisterCommentDto(
+        Long teamManageId,
+        String content
+) {
+}

--- a/src/main/java/kr/teammanagers/team/dto/SimpleTeamMemberDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/SimpleTeamMemberDto.java
@@ -1,0 +1,17 @@
+package kr.teammanagers.team.dto;
+
+import kr.teammanagers.team.domain.TeamManage;
+import lombok.Builder;
+
+@Builder
+public record SimpleTeamMemberDto(
+        Long teamManageId,
+        String name
+) {
+    public static SimpleTeamMemberDto from(final TeamManage teamManage) {
+        return SimpleTeamMemberDto.builder()
+                .teamManageId(teamManage.getId())
+                .name(teamManage.getMember().getName())
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/dto/TeamDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/TeamDto.java
@@ -1,5 +1,6 @@
 package kr.teammanagers.team.dto;
 
+import kr.teammanagers.tag.domain.Tag;
 import kr.teammanagers.tag.dto.TagDto;
 import kr.teammanagers.team.domain.Team;
 import lombok.Builder;
@@ -15,12 +16,15 @@ public record TeamDto(
         List<TagDto> teamTagList
 ) {
 
-    public static TeamDto from(final Team team) {
+    public static TeamDto from(final Team team, final List<Tag> tagList) {
         return TeamDto.builder()
                 .teamId(team.getId())
                 .title(team.getTitle())
                 .teamCode(team.getTeamCode())
                 .imageUrl(team.getTeamImageUrl())
+                .teamTagList(tagList.stream()
+                        .map(TagDto::from)
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/kr/teammanagers/team/dto/TeamMemberDto.java
+++ b/src/main/java/kr/teammanagers/team/dto/TeamMemberDto.java
@@ -1,0 +1,27 @@
+package kr.teammanagers.team.dto;
+
+import kr.teammanagers.tag.domain.Tag;
+import kr.teammanagers.tag.dto.TagDto;
+import kr.teammanagers.team.domain.TeamManage;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record TeamMemberDto(
+        Long teamManageId,
+        String name,
+        String imageUrl,
+        List<TagDto> roleList
+) {
+    public static TeamMemberDto of(final TeamManage teamManage, final List<Tag> tagList) {
+        return TeamMemberDto.builder()
+                .teamManageId(teamManage.getId())
+                .name(teamManage.getMember().getName())
+                .imageUrl(teamManage.getMember().getImageUrl())
+                .roleList(tagList.stream()
+                        .map(TagDto::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/dto/request/CreateTeam.java
+++ b/src/main/java/kr/teammanagers/team/dto/request/CreateTeam.java
@@ -1,0 +1,21 @@
+package kr.teammanagers.team.dto.request;
+
+import kr.teammanagers.common.Status;
+import kr.teammanagers.team.constant.TeamConstant;
+import kr.teammanagers.team.domain.Team;
+
+import java.util.List;
+
+public record CreateTeam(
+        String title,
+        List<String> teamTagList
+) {
+    public Team toTeam(final String imageUrl) {
+        return Team.builder()
+                .title(title)
+                .teamImageUrl(imageUrl)
+                .status(Status.PROCEEDING)
+                .password(TeamConstant.DEFAULT_TEAM_PASSWORD)
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/dto/request/CreateTeamComment.java
+++ b/src/main/java/kr/teammanagers/team/dto/request/CreateTeamComment.java
@@ -1,0 +1,10 @@
+package kr.teammanagers.team.dto.request;
+
+import kr.teammanagers.team.dto.RegisterCommentDto;
+
+import java.util.List;
+
+public record CreateTeamComment(
+        List<RegisterCommentDto> commentList
+) {
+}

--- a/src/main/java/kr/teammanagers/team/dto/request/CreateTeamPassword.java
+++ b/src/main/java/kr/teammanagers/team/dto/request/CreateTeamPassword.java
@@ -1,0 +1,6 @@
+package kr.teammanagers.team.dto.request;
+
+public record CreateTeamPassword(
+        String password
+) {
+}

--- a/src/main/java/kr/teammanagers/team/dto/response/CreateTeamResult.java
+++ b/src/main/java/kr/teammanagers/team/dto/response/CreateTeamResult.java
@@ -1,0 +1,17 @@
+package kr.teammanagers.team.dto.response;
+
+import kr.teammanagers.team.domain.Team;
+import lombok.Builder;
+
+@Builder
+public record CreateTeamResult(
+        Long teamId,
+        String teamCode
+) {
+    public static CreateTeamResult from(final Team team) {
+        return CreateTeamResult.builder()
+                .teamId(team.getId())
+                .teamCode(team.getTeamCode())
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/dto/response/GetTeam.java
+++ b/src/main/java/kr/teammanagers/team/dto/response/GetTeam.java
@@ -1,0 +1,19 @@
+package kr.teammanagers.team.dto.response;
+
+import kr.teammanagers.tag.domain.Tag;
+import kr.teammanagers.team.domain.Team;
+import kr.teammanagers.team.dto.TeamDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetTeam(
+        TeamDto team
+) {
+    public static GetTeam from(final Team team, final List<Tag> tagList) {
+        return GetTeam.builder()
+                .team(TeamDto.from(team, tagList))
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/dto/response/GetTeamMember.java
+++ b/src/main/java/kr/teammanagers/team/dto/response/GetTeamMember.java
@@ -1,0 +1,17 @@
+package kr.teammanagers.team.dto.response;
+
+import kr.teammanagers.team.dto.SimpleTeamMemberDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetTeamMember(
+        List<SimpleTeamMemberDto> teamMember
+) {
+    public static GetTeamMember from(final List<SimpleTeamMemberDto> teamMember) {
+        return GetTeamMember.builder()
+                .teamMember(teamMember)
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/dto/response/UpdateTeamEndResult.java
+++ b/src/main/java/kr/teammanagers/team/dto/response/UpdateTeamEndResult.java
@@ -1,0 +1,17 @@
+package kr.teammanagers.team.dto.response;
+
+import kr.teammanagers.team.dto.TeamMemberDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UpdateTeamEndResult(
+        List<TeamMemberDto> teamMemberList
+) {
+    public static UpdateTeamEndResult from(List<TeamMemberDto> teamMemberList) {
+        return UpdateTeamEndResult.builder()
+                .teamMemberList(teamMemberList)
+                .build();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/presentation/TeamController.java
+++ b/src/main/java/kr/teammanagers/team/presentation/TeamController.java
@@ -1,0 +1,87 @@
+package kr.teammanagers.team.presentation;
+
+import kr.teammanagers.common.payload.code.ApiPayload;
+import kr.teammanagers.team.application.TeamService;
+import kr.teammanagers.team.dto.request.CreateTeam;
+import kr.teammanagers.team.dto.request.CreateTeamComment;
+import kr.teammanagers.team.dto.request.CreateTeamPassword;
+import kr.teammanagers.team.dto.response.CreateTeamResult;
+import kr.teammanagers.team.dto.response.GetTeam;
+import kr.teammanagers.team.dto.response.GetTeamMember;
+import kr.teammanagers.team.dto.response.UpdateTeamEndResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @PostMapping("/team")
+    public ApiPayload<CreateTeamResult> create(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @RequestPart(name = "createTeam") final CreateTeam createTeam,
+            @RequestPart(name = "imageFile", required = false) final MultipartFile imageFile
+    ) {
+        CreateTeamResult result = teamService.createTeam(1L, createTeam, imageFile);       // TODO : 인증 객체 구현시 auth.id로 변경 필요
+        return ApiPayload.onSuccess(result);
+    }
+
+    @PatchMapping("/team/{teamId}/password")
+    public ApiPayload<Void> createPassword(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @PathVariable("teamId") final Long teamId,
+            @RequestBody final CreateTeamPassword createTeamPassword
+    ) {
+        teamService.createTeamPassword(teamId, createTeamPassword);
+        return ApiPayload.onSuccess();
+    }
+
+    @GetMapping("/team/{teamId}")
+    public ApiPayload<GetTeam> getById(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @PathVariable("teamId") final Long teamId
+    ) {
+        GetTeam result = teamService.getTeamById(teamId);
+        return ApiPayload.onSuccess(result);
+    }
+
+    @GetMapping("/team")
+    public ApiPayload<GetTeam> getByTeamCode(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @RequestParam("teamCode") final String teamCode
+    ) {
+        GetTeam result = teamService.getTeamByTeamCode(teamCode);
+        return ApiPayload.onSuccess(result);
+    }
+
+    @GetMapping("/team/{teamId}/member")
+    public ApiPayload<GetTeamMember> getTeamMember(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @PathVariable("teamId") final Long teamId
+    ) {
+        GetTeamMember result = teamService.getTeamMember(teamId);
+        return ApiPayload.onSuccess(result);
+    }
+
+    @PatchMapping("/team/{teamId}/state")
+    public ApiPayload<UpdateTeamEndResult> updateTeamState(
+//            @AuthenticationPrincipal final AuthDto auth,          // TODO : 인증 객체 구현 필요
+            @PathVariable("teamId") final Long teamId
+    ) {
+        UpdateTeamEndResult result = teamService.updateTeamState(1L, teamId);
+        return ApiPayload.onSuccess(result);
+    }
+
+    @PostMapping("/team/comment")
+    public ApiPayload<Void> createComment(
+//            @AuthenticationPrincipal final AuthDto auth         // TODO : 인증 객체 구현 필요
+            @RequestBody final CreateTeamComment createTeamComment
+    ) {
+        teamService.createComment(createTeamComment);
+        return ApiPayload.onSuccess();
+    }
+}

--- a/src/main/java/kr/teammanagers/team/repository/TeamRepository.java
+++ b/src/main/java/kr/teammanagers/team/repository/TeamRepository.java
@@ -3,5 +3,9 @@ package kr.teammanagers.team.repository;
 import kr.teammanagers.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByTeamCode(final String teamCode);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
- #26 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 팀 생성 기능 구현 완료
- 팀 비밀번호 생성 기능 구현 완료
- 팀 조회 기능 구현 완료
- 팀 조회 (팀 코드) 기능 구현 완료
- 팀 멤버 조회 기능 구현 완료
- 팀 종료 기능 구현 완료
- 팀 멤버 코멘트 생성 기능 구현 완료
- 팀 관련 도메인 API 구현 완료
- 팀 최신 공지 조회 기능 구현 완료

### 📸 스크린샷 (선택)

### 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 팀 조회시 팀의 태그가 누락되는 오류가 발견되어서 수정하였습니다.
- 팀 테이블에 `password` 필드가 누락되어 있어 추가하였습니다.
- 도메인 명명 정책에 따라 `calendar` 테이블과 `schedule` 패키지를 교체하였습니다.